### PR TITLE
Add DRF viewsets and admin registrations

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -1,3 +1,21 @@
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+from .models import User
 
-# Register your models here.
+@admin.register(User)
+class UserAdmin(BaseUserAdmin):
+    list_display = ('email', 'name', 'role', 'company', 'is_staff')
+    list_filter = ('role', 'is_staff')
+    search_fields = ('email', 'name')
+    fieldsets = (
+        (None, {'fields': ('email', 'password')}),
+        ('Personal info', {'fields': ('name', 'role', 'company')}),
+        ('Permissions', {'fields': ('is_active', 'is_staff', 'is_superuser', 'groups', 'user_permissions')}),
+    )
+    add_fieldsets = (
+        (None, {
+            'classes': ('wide',),
+            'fields': ('email', 'name', 'role', 'password1', 'password2', 'company'),
+        }),
+    )
+    ordering = ('email',)

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,3 +1,8 @@
-from django.shortcuts import render
+from rest_framework import viewsets, permissions
+from .models import User
+from .serializers import UserSerializer
 
-# Create your views here.
+class UserViewSet(viewsets.ModelViewSet):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+    permission_classes = [permissions.IsAuthenticated]

--- a/cash/admin.py
+++ b/cash/admin.py
@@ -1,3 +1,8 @@
 from django.contrib import admin
+from .models import CashMovement
 
-# Register your models here.
+@admin.register(CashMovement)
+class CashMovementAdmin(admin.ModelAdmin):
+    list_display = ('tipo', 'monto', 'fecha', 'chofer', 'company')
+    list_filter = ('tipo', 'company')
+    search_fields = ('motivo',)

--- a/cash/serializers.py
+++ b/cash/serializers.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from .models import CashMovement
+
+class CashMovementSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CashMovement
+        fields = '__all__'

--- a/cash/views.py
+++ b/cash/views.py
@@ -1,3 +1,8 @@
-from django.shortcuts import render
+from rest_framework import viewsets, permissions
+from .models import CashMovement
+from .serializers import CashMovementSerializer
 
-# Create your views here.
+class CashMovementViewSet(viewsets.ModelViewSet):
+    queryset = CashMovement.objects.all()
+    serializer_class = CashMovementSerializer
+    permission_classes = [permissions.IsAuthenticated]

--- a/companies/admin.py
+++ b/companies/admin.py
@@ -1,3 +1,7 @@
 from django.contrib import admin
+from .models import Company
 
-# Register your models here.
+@admin.register(Company)
+class CompanyAdmin(admin.ModelAdmin):
+    list_display = ('name', 'rut', 'email', 'created_at')
+    search_fields = ('name', 'rut')

--- a/companies/serializers.py
+++ b/companies/serializers.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from .models import Company
+
+class CompanySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Company
+        fields = '__all__'

--- a/companies/views.py
+++ b/companies/views.py
@@ -1,3 +1,8 @@
-from django.shortcuts import render
+from rest_framework import viewsets, permissions
+from .models import Company
+from .serializers import CompanySerializer
 
-# Create your views here.
+class CompanyViewSet(viewsets.ModelViewSet):
+    queryset = Company.objects.all()
+    serializer_class = CompanySerializer
+    permission_classes = [permissions.IsAuthenticated]

--- a/config/urls.py
+++ b/config/urls.py
@@ -19,10 +19,29 @@ from django.contrib import admin
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 from reports.views import ReportViewSet
-from geolocation.views import DriverLocationUpdateView
+from geolocation.views import DriverLocationUpdateView, DriverLocationViewSet
+from accounts.views import UserViewSet
+from companies.views import CompanyViewSet
+from inventory.views import (
+    WarehouseViewSet,
+    CylinderTypeViewSet,
+    CylinderStockViewSet,
+)
+from orders.views import OrderViewSet
+from cash.views import CashMovementViewSet
+from subscriptions.views import SubscriptionViewSet
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 router = DefaultRouter()
+router.register(r"users", UserViewSet)
+router.register(r"companies", CompanyViewSet)
+router.register(r"warehouses", WarehouseViewSet)
+router.register(r"cylinder-types", CylinderTypeViewSet)
+router.register(r"cylinder-stocks", CylinderStockViewSet)
+router.register(r"orders", OrderViewSet)
+router.register(r"cash-movements", CashMovementViewSet)
+router.register(r"subscriptions", SubscriptionViewSet)
+router.register(r"locations", DriverLocationViewSet)
 router.register(r"reports", ReportViewSet, basename="report")
 
 urlpatterns = [

--- a/geolocation/admin.py
+++ b/geolocation/admin.py
@@ -1,3 +1,8 @@
 from django.contrib import admin
+from .models import DriverLocation
 
-# Register your models here.
+@admin.register(DriverLocation)
+class DriverLocationAdmin(admin.ModelAdmin):
+    list_display = ('chofer', 'latitud', 'longitud', 'timestamp')
+    list_filter = ('chofer',)
+    search_fields = ('chofer__email',)

--- a/geolocation/serializers.py
+++ b/geolocation/serializers.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from .models import DriverLocation
+
+class DriverLocationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = DriverLocation
+        fields = '__all__'

--- a/geolocation/views.py
+++ b/geolocation/views.py
@@ -1,7 +1,7 @@
-from rest_framework import permissions, status, views
+from rest_framework import permissions, status, views, viewsets
 from rest_framework.response import Response
 from .models import DriverLocation
-
+from .serializers import DriverLocationSerializer
 
 class DriverLocationUpdateView(views.APIView):
     permission_classes = [permissions.IsAuthenticated]
@@ -15,3 +15,9 @@ class DriverLocationUpdateView(views.APIView):
             longitud=lng,
         )
         return Response({'status': 'ok'}, status=status.HTTP_201_CREATED)
+
+
+class DriverLocationViewSet(viewsets.ModelViewSet):
+    queryset = DriverLocation.objects.all()
+    serializer_class = DriverLocationSerializer
+    permission_classes = [permissions.IsAuthenticated]

--- a/inventory/admin.py
+++ b/inventory/admin.py
@@ -1,3 +1,17 @@
 from django.contrib import admin
+from .models import Warehouse, CylinderType, CylinderStock
 
-# Register your models here.
+@admin.register(Warehouse)
+class WarehouseAdmin(admin.ModelAdmin):
+    list_display = ('name', 'address', 'company')
+    search_fields = ('name',)
+
+@admin.register(CylinderType)
+class CylinderTypeAdmin(admin.ModelAdmin):
+    list_display = ('name', 'weight', 'capacity')
+    search_fields = ('name',)
+
+@admin.register(CylinderStock)
+class CylinderStockAdmin(admin.ModelAdmin):
+    list_display = ('cylinder_type', 'warehouse', 'quantity', 'company')
+    list_filter = ('company',)

--- a/inventory/serializers.py
+++ b/inventory/serializers.py
@@ -1,0 +1,17 @@
+from rest_framework import serializers
+from .models import Warehouse, CylinderType, CylinderStock
+
+class WarehouseSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Warehouse
+        fields = '__all__'
+
+class CylinderTypeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CylinderType
+        fields = '__all__'
+
+class CylinderStockSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CylinderStock
+        fields = '__all__'

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -1,3 +1,22 @@
-from django.shortcuts import render
+from rest_framework import viewsets, permissions
+from .models import Warehouse, CylinderType, CylinderStock
+from .serializers import (
+    WarehouseSerializer,
+    CylinderTypeSerializer,
+    CylinderStockSerializer,
+)
 
-# Create your views here.
+class WarehouseViewSet(viewsets.ModelViewSet):
+    queryset = Warehouse.objects.all()
+    serializer_class = WarehouseSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+class CylinderTypeViewSet(viewsets.ModelViewSet):
+    queryset = CylinderType.objects.all()
+    serializer_class = CylinderTypeSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+class CylinderStockViewSet(viewsets.ModelViewSet):
+    queryset = CylinderStock.objects.all()
+    serializer_class = CylinderStockSerializer
+    permission_classes = [permissions.IsAuthenticated]

--- a/orders/admin.py
+++ b/orders/admin.py
@@ -1,3 +1,10 @@
 from django.contrib import admin
+from .models import Order
 
-# Register your models here.
+@admin.register(Order)
+class OrderAdmin(admin.ModelAdmin):
+    list_display = (
+        'cliente_nombre', 'estado', 'forma_pago', 'tipo_cilindro', 'chofer', 'company'
+    )
+    list_filter = ('estado', 'forma_pago', 'company')
+    search_fields = ('cliente_nombre', 'direccion')

--- a/orders/serializers.py
+++ b/orders/serializers.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from .models import Order
+
+class OrderSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Order
+        fields = '__all__'

--- a/orders/views.py
+++ b/orders/views.py
@@ -1,3 +1,8 @@
-from django.shortcuts import render
+from rest_framework import viewsets, permissions
+from .models import Order
+from .serializers import OrderSerializer
 
-# Create your views here.
+class OrderViewSet(viewsets.ModelViewSet):
+    queryset = Order.objects.all()
+    serializer_class = OrderSerializer
+    permission_classes = [permissions.IsAuthenticated]

--- a/subscriptions/admin.py
+++ b/subscriptions/admin.py
@@ -1,3 +1,8 @@
 from django.contrib import admin
+from .models import Subscription
 
-# Register your models here.
+@admin.register(Subscription)
+class SubscriptionAdmin(admin.ModelAdmin):
+    list_display = ('company', 'activa', 'inicio', 'vencimiento')
+    list_filter = ('activa',)
+    search_fields = ('company__name',)

--- a/subscriptions/serializers.py
+++ b/subscriptions/serializers.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from .models import Subscription
+
+class SubscriptionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Subscription
+        fields = '__all__'

--- a/subscriptions/views.py
+++ b/subscriptions/views.py
@@ -1,3 +1,8 @@
-from django.shortcuts import render
+from rest_framework import viewsets, permissions
+from .models import Subscription
+from .serializers import SubscriptionSerializer
 
-# Create your views here.
+class SubscriptionViewSet(viewsets.ModelViewSet):
+    queryset = Subscription.objects.all()
+    serializer_class = SubscriptionSerializer
+    permission_classes = [permissions.IsAuthenticated]


### PR DESCRIPTION
## Summary
- implement `ModelViewSet` views across apps
- create serializers for each model
- register models in `admin.py` for admin interface
- wire up all viewsets in `config/urls.py`
- update dependencies for running Django

## Testing
- `pip install -r requirements.txt`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68619eb4c3dc832fb2c90833f9868c69